### PR TITLE
Fix calendar parsing for new MyUW Vue schedule cards

### DIFF
--- a/js/insertButton.js
+++ b/js/insertButton.js
@@ -8,14 +8,16 @@ function addButton(schedule) {
 }
 
 function grabSchedule () {
-  console.log("Test");
-  window.postMessage({ type: "schedule", schedule: JSON.stringify(WSData.course_data_for_term(VisualScheduleCard.term))}, "*");
-  window.postMessage({ type: "newTab", newSchedule: JSON.stringify(WSData.course_data_for_term(VisualScheduleCard.term))}, "*");
+  const schedule = document.getElementById('myuw-visual-schedule').__vue__.$store.state.visual_schedule.value.current;
+  schedule.sections = schedule.periods[0].sections;
+  window.postMessage({ type: "schedule", schedule: JSON.stringify(schedule)}, "*");
+  window.postMessage({ type: "newTab", newSchedule: JSON.stringify(schedule)}, "*");
 }
 
-let oldHandler = VisualScheduleCard.render_handler;
-VisualScheduleCard.render_handler = function() {
-  oldHandler();
-  addButton(VisualScheduleCard.dom_target[0])
-}
-VisualScheduleCard.render_init()
+const buttonTimer = setInterval(() => {
+  const ele = document.getElementById('myuw-visual-schedule');
+  if (ele) {
+      addButton(ele.children[0]);
+      clearInterval(buttonTimer);
+  }
+}, 500);

--- a/js/schedule.js
+++ b/js/schedule.js
@@ -34,8 +34,7 @@ function Schedule(newSchedule) {
           location = "Room TBD";
         }
 
-        let dateSplit = response.term.first_day_quarter.split('-');
-        let first_day = new Date(dateSplit[0], dateSplit[1] - 1, dateSplit[2]);
+        let first_day = new Date(response.term.first_day_quarter);
         if (days.length > 0) {
           while (!days.includes(this.WEEKDAYS[first_day.getDay()])) {
             first_day.setDate(first_day.getDate() + 1);
@@ -65,8 +64,8 @@ function Schedule(newSchedule) {
           "title": section.curriculum_abbr + " " + section.course_number + " (" + type + ")",
           "description": section.curriculum_abbr + " " + section.course_number + " - " + section.course_title,
           "location": location,
-          "start_time": (section.meetings[j].start_time) ? (first_day.toISOString().substring(0, 10) + " " + section.meetings[j].start_time) : null,
-          "end_time": (section.meetings[j].start_time) ? (first_day.toISOString().substring(0, 10) + " " + section.meetings[j].end_time) : null,
+          "start_time": (section.meetings[j].start_time) ? (first_day.toISOString().substring(0, 10) + "T" + section.meetings[j].start_time.substring(11)) : null,
+          "end_time": (section.meetings[j].start_time) ? (first_day.toISOString().substring(0, 10) + "T" + section.meetings[j].end_time.substring(11)) : null,
           "freq": "WEEKLY",
           "until": end_date.toString(),
           "byday": days


### PR DESCRIPTION
MyUW recently went through a [restructure](https://github.com/uw-it-aca/myuw/pull/2678), where many components including the schedule card became [Vue components](https://github.com/uw-it-aca/myuw/blob/main/myuw_vue/components/_common/visual_schedule/schedule.vue). This breaks this extension, as it can no longer read the calendar data, or place the icon to begin with.

This PR allows for the extension to be invoked by adding the icon back to the card, as well as fixes the ability to parse the schedule data.

Instead of hijacking the card's render handler, a timer is used to periodically check if the card has rendered before adding the icon. Perhaps this does not feel like the best solution.

The structure of the schedule data when pulled from the Vue store seems to be a little different, but it appears to work.

## Existing Behavior

![screenshot of schedule with no icon and error in console](https://user-images.githubusercontent.com/6354860/162126047-aeb4acaf-b933-41b8-8120-c1ed5d9f402d.png)

Icon is not added to the card due to an error.

## Proposed Behavior

![screencast](https://user-images.githubusercontent.com/6354860/162125777-5599bfa1-3d2c-4712-bba6-8636ba2c3dc9.gif)
